### PR TITLE
Add root MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matters Lab
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE-CONTENT.md
+++ b/LICENSE-CONTENT.md
@@ -1,0 +1,10 @@
+# Content license
+
+Except where a file or passage identifies a different source or license, the
+original prose and documentation in this repository are dedicated to the
+public domain under
+[CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).
+
+This dedication does not apply to third-party material, user-generated
+content, trademarks, logos, or product names. Source code is licensed
+separately under the repository's root `LICENSE` file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "matters-email",
       "version": "2.1.3",
-      "license": "UNLICENSED",
+      "license": "MIT",
       "dependencies": {
         "@types/request": "^2.48.5",
         "@types/request-promise-native": "^1.0.17",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint . --ext .ts,.tsx"
   },
   "author": "",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",


### PR DESCRIPTION
Adds the repository's root MIT license and dedicates original documentation to CC0, while excluding third-party material and trademarks. No runtime behavior changes.